### PR TITLE
doc: feedback and clarifications

### DIFF
--- a/extensions/ICRC-2/BUILD.bazel
+++ b/extensions/ICRC-2/BUILD.bazel
@@ -1,0 +1,25 @@
+load("//bazel:didc_test.bzl", "didc_subtype_test")
+
+exports_files([
+    "ICRC-2.did",
+])
+
+genrule(
+    name = "candid",
+    srcs = [":README.md"],
+    outs = ["ICRC-2-generated.did"],
+    cmd_bash = "$(location @lmt) $(SRCS); mv ICRC-2.did $@",
+    exec_tools = ["@lmt"],
+)
+
+didc_subtype_test(
+    name = "check_generated_subtype",
+    did = ":ICRC-2-generated.did",
+    previous = "ICRC-2.did",
+)
+
+didc_subtype_test(
+    name = "check_source_subtype",
+    did = "ICRC-2.did",
+    previous = ":ICRC-2-generated.did",
+)

--- a/extensions/ICRC-2/ICRC-2.did
+++ b/extensions/ICRC-2/ICRC-2.did
@@ -1,41 +1,6 @@
-// Number of nanoseconds since the UNIX epoch in UTC timezone.
-type Timestamp = nat64;
-
-// Number of nanoseconds between two [Timestamp]s.
-type Duration = nat64;
-
-type Subaccount = blob;
-
 type Account = record {
     owner : principal;
-    subaccount : opt Subaccount;
-};
-
-type TransferArgs = record {
-    from_subaccount : opt Subaccount;
-    to : Account;
-    amount : nat;
-    fee : opt nat;
-    memo : opt blob;
-    created_at_time : opt Timestamp;
-};
-
-type TransferError = variant {
-    BadFee : record { expected_fee : nat };
-    BadBurn : record { min_burn_amount : nat };
-    InsufficientFunds : record { balance : nat };
-    TooOld;
-    CreatedInFuture: record { ledger_time : Timestamp };
-    Duplicate : record { duplicate_of : nat };
-    TemporarilyUnavailable;
-    GenericError : record { error_code : nat; message : text };
-};
-
-type Value = variant {
-    Nat : nat;
-    Int : int;
-    Text : text;
-    Blob : blob;
+    subaccount : opt blob;
 };
 
 type ApproveArgs = record {
@@ -44,6 +9,16 @@ type ApproveArgs = record {
     fee : opt nat;
     memo : opt blob;
     created_at_time : opt nat64;
+};
+
+type ApproveError = variant {
+    BadFee : record { expected_fee : nat };
+    InsufficientFunds : record { balance : nat };
+    TooOld;
+    CreatedInFuture: record { ledger_time : nat64 };
+    Duplicate : record { duplicate_of : nat };
+    TemporarilyUnavailable;
+    GenericError : record { error_code : nat; message : text };
 };
 
 type TransferFromArgs = record {
@@ -55,24 +30,27 @@ type TransferFromArgs = record {
     created_at_time : opt nat64;
 };
 
+type TransferFromError = variant {
+    BadFee : record { expected_fee : nat };
+    BadBurn : record { min_burn_amount : nat };
+    InsufficientFunds : record { balance : nat };
+    InsufficientAllowance : record { allowance : nat };
+    TooOld;
+    CreatedInFuture: record { ledger_time : nat64 };
+    Duplicate : record { duplicate_of : nat };
+    TemporarilyUnavailable;
+    GenericError : record { error_code : nat; message : text };
+};
+
 type AllowanceArgs = record {
-    owner : Account;
+    account : Account;
     spender : principal;
 };
 
 service : {
-    icrc1_metadata : () -> (vec record { text; Value; }) query;
-    icrc1_name : () -> (text) query;
-    icrc1_symbol : () -> (text) query;
-    icrc1_decimals : () -> (nat8) query;
-    icrc1_fee : () -> (nat) query;
-    icrc1_total_supply : () -> (nat) query;
-    icrc1_minting_account : () -> (opt Account) query;
-    icrc1_balance_of : (Account) -> (nat) query;
-    icrc1_transfer : (TransferArgs) -> (variant { Ok : nat; Err : TransferError });
     icrc1_supported_standards : () -> (vec record { name : text; url : text }) query;
 
-    icrc2_approve : (ApproveArgs) -> (variant { Ok } | variant { Err : TransferError });
-    icrc2_transfer_from : (TransferFromArgs) -> (variant { Ok : nat; Err : TransferError });
+    icrc2_approve : (ApproveArgs) -> (variant { Ok : nat; Err : ApproveError });
+    icrc2_transfer_from : (TransferFromArgs) -> (variant { Ok : nat; Err : TransferFromError });
     icrc2_allowance : (AllowanceArgs) -> (nat) query;
 }

--- a/extensions/ICRC-2/README.md
+++ b/extensions/ICRC-2/README.md
@@ -2,15 +2,26 @@
 
 ## Abstract
 
-`ICRC-2` is an extension to the base `ICRC-1` standard. It adds the ability to approve a third party, and then that third party can transfer tokens on your behalf.
+`ICRC-2` is an extension of the base `ICRC-1` standard.
+`ICRC-2` specifies a way for an account owner to delegate token transfers to a third party on the owner's behalf.
 
 The approve and transfer-from flow is a 2-step process.
-1. Signer A approves X tokens for signer b
-2. Signer B can transfer on behalf of signer A, up to the allowance X, or Signer B’s total balance
+1. Account owner Alice entitles principal Bob to transfer up to X tokens from her account A by calling the `icrc2_approve` method on the ledger.
+2. Bob can transfer up to X tokens from account A to any account by calling the `icrc2_transfer_from` method on the ledger.
+   The number of transfers Bob can initiate from account A is not limited as long as the total amount spent is below X.
 
 ## Motivation
 
-At the time of writing, the base `ICRC-1` standard does not have first class support for canister based interactions. This is because the `transfer` method does not allow for a third-party to transfer tokens on behalf of a user. This is a common pattern in the ERC20 standard, and is useful for canister based interactions.
+The approve-transfer-from pattern became popular in the Ethereum ecosystem thanks to the [ERC-20](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) token standard.
+This interface enables new application capabilities:
+
+  1. Recurring payments.
+     Alice can approve a large amount to Bob in advance, allowing Bob to make periodic transfers in small installments.
+     Real-world examples include subscription services and rents.
+
+  2. Uncertain transfer amounts.
+     In some applications, such as automatic trading services, the exact price of goods is unknown in advance.
+     With approve-transfer-from flow, Alice can allow Bob to trade securities on Alice's behalf, buying/selling at yet-unknown price up to a specified limit.
 
 ## Specification
 
@@ -20,15 +31,78 @@ At the time of writing, the base `ICRC-1` standard does not have first class sup
 
 **Canisters implementing the `ICRC-2` standard MUST include `ICRC-2` in the list returned by the `icrc1_supported_standards` method**
 
-```candid
-// The `ICRC-2` standard extends the `ICRC-1` standard
+## Methods
 
+```candid "Type definitions" +=
+type Account = record {
+    owner : principal;
+    subaccount : opt blob;
+};
+```
+
+### icrc2_approve
+
+Entitles `spender` to transfer at most the provided token `amount` on behalf of the caller from account `{ owner = caller; subaccount = from_subaccount }`.
+The number of transfers the `spender` can initiate from the caller's account is unlimited as long as the total amounts and fees of these transfers do not exceed the allowance.
+The caller does not need to have the full token `amount` on the specified account for the approval to succeed, just enough tokens to pay the approval fee.
+The new `spender`'s allowance for the account overrides the previous allowance value. 
+
+```candid "Methods" +=
+icrc2_approve : (ApproveArgs) -> (variant { Ok : nat; Err : ApproveError });
+```
+
+```candid "Type definitions" +=
 type ApproveArgs = record {
+    from_subaccount : opt blob;
     spender : principal;
     amount : nat;
     fee : opt nat;
     memo : opt blob;
     created_at_time : opt nat64;
+};
+
+type ApproveError = variant {
+    BadFee : record { expected_fee : nat };
+    // The caller does not have enough funds to pay the approval fee.
+    InsufficientFunds : record { balance : nat };
+    TooOld;
+    CreatedInFuture: record { ledger_time : nat64 };
+    Duplicate : record { duplicate_of : nat };
+    TemporarilyUnavailable;
+    GenericError : record { error_code : nat; message : text };
+};
+```
+
+#### Preconditions
+
+* The caller has enough fees on the `{ owner = caller; subaccount = from_subaccount }` account to pay the approval fee.
+
+#### Postconditions
+
+* `spender`'s allowance for the `{ owner = caller; subaccount = from_subaccount }` account is `amount`.
+
+### icrc2_transfer_from
+
+Transfers a token amount from between two accounts.
+The ledger draws the fees from the `from` account.
+
+```candid "Methods" +=
+icrc2_transfer_from : (TransferFromArgs) -> (variant { Ok : nat; Err : TransferFromError });
+```
+
+```candid "Type definitions" +=
+type TransferFromError = variant {
+    BadFee : record { expected_fee : nat };
+    BadBurn : record { min_burn_amount : nat };
+    // The [from] account does not hold enough funds for the transfer.
+    InsufficientFunds : record { balance : nat };
+    // The caller exceeded its allowance.
+    InsufficientAllowance : record { allowance : nat };
+    TooOld;
+    CreatedInFuture: record { ledger_time : nat64 };
+    Duplicate : record { duplicate_of : nat };
+    TemporarilyUnavailable;
+    GenericError : record { error_code : nat; message : text };
 };
 
 type TransferFromArgs = record {
@@ -39,60 +113,73 @@ type TransferFromArgs = record {
     memo : opt blob;
     created_at_time : opt nat64;
 };
-
-type AllowanceArgs = record {
-    owner : Account;
-    spender : principal;
-};
-
-service : {
-    icrc1_* : (*) -> *;
-    
-    icrc2_approve : (ApproveArgs) -> (variant { Ok } | variant { Err : TransferError });
-    icrc2_transfer_from : (TransferFromArgs) -> (variant { Ok : nat; Err : TransferError });
-    icrc2_allowance : (AllowanceArgs) -> (nat) query;
-}
 ```
 
-## Implementation Guidelines
+#### Preconditions
+ 
+ * The caller's allowance for the `from` account is large enough to include the transfer amount and the fees.
+   Otherwise, the ledger MUST return an `InsufficientAllowance` error.
 
-### Approve (`icrc2_approve`)
+* The `from` account holds enough funds to cover the transfer amount and the fees.
+  Otherwise, the ledger MUST return an `InsufficientFunds` error.
+ #### Postconditions
 
-- If a user sets an allowance of 0, it is equivalent to removing the allowance, and canisters SHOULD remove the allowance from their internal state
+ * Caller's allowance for the `from` account decreases by the transfer amount and the fees.
+ * The ledger debited the specified `amount` of tokens and fees from the `from` account.
+ * The ledger credited the specified `amount` to the `to` account.
 
-### Transfer-From (`icrc2_transfer_from`)
+### icrc2_allowance
 
-- The allowance is checked before the transfer is executed, and the allowance is decremented after the transfer is executed
-- If the `from` account does not have enough tokens to transfer, the canister MUST return `InsufficientFunds` error
-- If the `caller` does not have enough allowance for `from` to transfer, the canister MUST return `InsufficientAllowance` error
+Returns the token allowance that the `spender` can transfer from the specified `account`.
+If there is no corresponding active approval, the ledger MUST return `0`.
 
-### Allowance (`icrc2_allowance`)
+```candid "Methods" +=
+icrc2_allowance : (AllowanceArgs) -> (nat) query;
+```
+```candid "Type definitions" +=
+type AllowanceArgs = record {
+    account : Account;
+    spender : principal;
+};
+```
+### icrc1_supported_standards
 
-- The canister MUST return the total allowance for the given `owner` and `spender`
-- The canister MUST return `0` if the allowance does not exist
+Returns the list of standards this ledger supports.
+Any ledger supporting `ICRC-2` MUST include a record with the `name` field equal to `"ICRC-2"` in that list.
 
-### Supported Standards List (`icrc1_supported_standards`)
-
-- The canister MUST include `ICRC-2` in the list returned by the `icrc1_supported_standards` method
+```candid "Methods" +=
+icrc1_supported_standards : () -> (vec record { name : text; url : text }) query;
+```
 
 ## Examples
 
 ### Alice deposits tokens to a canister
 
-1. Alice wants to deposit 100 tokens on an `ICRC-2` ledger to a canister id
-2. Alice calls `icrc2_approve` with `spender` set to the canister's principal, and `amount` set to the amount of tokens she wants to deposit (100).
-3. Alice can then call some `deposit` method on the canister, which calls `icrc2_transfer_from` with `from` set to Alice's (the caller) account, `to` set to the canister's account, and `amount` set to the amount of tokens she wants to deposit (100).
-4. The canister can now determine from the result of the call if the transfer was successful or not. If it was successful, the canister can now commit the deposit to state safely and know that the tokens are in its account.
+1. Alice wants to deposit 100 tokens on an `ICRC-2` ledger to a canister.
+2. Alice calls `icrc2_approve` with `spender` set to the canister's principal and `amount` set to the token amount she wants to deposit (100) plus the transfer fee.
+3. Alice can then call some `deposit` method on the canister, which calls `icrc2_transfer_from` with `from` set to Alice's (the caller) account, `to` set to the canister's account, and `amount` set to the token amount she wants to deposit (100).
+4. The canister can now determine from the result of the call whether the transfer was successful.
+   If it was successful, the canister can now safely commit the deposit to state and know that the tokens are in its account.
 
 ### A canister transfers tokens from Alice's account to Bob's account, on Alice's behalf
 
-1. A canister wants to transfer 100 tokens on an `ICRC-2` ledger from Alice's account to Bob's account
-2. Alice previously approved the canister to transfer tokens on her behalf by calling `icrc2_approve` with `spender` set to the canister's principal, and `amount` set to the amount of tokens she wants to allow (100).
-3. During some update call, the canister can now call `icrc2_transfer_from` with `from` set to Alice's account, `to` set to Bob's account, and `amount` set to the amount of tokens she wants to transfer (100).
+1. A canister wants to transfer 100 tokens on an `ICRC-2` ledger from Alice's account to Bob's account.
+2. Alice previously approved the canister to transfer tokens on her behalf by calling `icrc2_approve` with `spender` set to the canister's principal and `amount` set to the token amount she wants to allow (100) plus the transfer fee.
+3. During some update call, the canister can now call `icrc2_transfer_from` with `from` set to Alice's account, `to` set to Bob's account, and `amount` set to the token amount she wants to transfer (100).
 4. Depending on the result of the call, Bob now has 100 tokens in his account, and Alice has 100 tokens less in her account.
 
 ### Alice wants to remove her allowance for a canister
 
-1. Alice wants to remove her allowance of 100 tokens on an `ICRC-2` ledger for a canister
-2. Alice calls `icrc2_approve` on the ledger with `spender` set to the canister's principal, and `amount` set to 0.
-3. The canister can now no longer transfer tokens on Alice's behalf.
+1. Alice wants to remove her allowance of 100 tokens on an `ICRC-2` ledger for a canister.
+2. Alice calls `icrc2_approve` on the ledger with `spender` set to the canister's principal and `amount` set to 0.
+3. The canister can no longer transfer tokens on Alice's behalf.
+
+<!--
+```candid ICRC-2.did +=
+<<<Type definitions>>>
+
+service : {
+  <<<Methods>>>
+}
+```
+-->


### PR DESCRIPTION
Highlights:

* [infra] Added a BUILD file to check that the types and methods in the README file match the `ICRC-2.did` file.
* [spec] Removed the "Signer" terminology as I couldn't find its past usage (e.g., it does not appear in the IC spec or the ICP Ledger spec).
* [spec] Extended the "Motivation" section to list new types of applications that the standard makes possible.
* [spec] Added a missing `from_subaccount` field in `ApproveArgs`.
* [spec] Refined the Error types returned from the `approve` and `transfer_from` methods. The `ApproveError` variant doesn't have the `BadBurn` case, and `TransferFromError` has an extra `InsufficientAllowance` case.
* [spec] Added explicit preconditions and postconditions for each method.
* [spec] Clarified that the approver pays all the fees.
* [spec] Clarified that `approve` overrides the previous allowance.
* [spec] Renamed `AllowanceArgs.owner` to `AllowanceArgs.account` to be more consistent ("owner" is usually a principal).